### PR TITLE
Add `ignore` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ _dtrim.trimmer([options])_
   - `string`: `<number>` Trim strings that are longer than specified number. To make it return full structure, pass `Infinity` or some arbitrary large number. _Default_: `512`.
   - `buffer`: `<boolean>` Substitues instances of a `Buffer` object with their string representation: `"Buffer(N)"`. _Default_: `true`.
   - `getters`: `<boolean>` Omits getter fields in objects and classes from the result. _Default_: `true`.
+  - `ignore`: `<Record<string, unknown>>` A record of paths to ignore while at depth 0. For example trimming `{a: FooClass}` with `{ignore: { a: true }}` will result in `{a: FooClass}`. _Default_: `{}`
 
 - Returns: `<Function>` - trimmer function that accepts input argument of any type.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ _dtrim.trimmer([options])_
   - `string`: `<number>` Trim strings that are longer than specified number. To make it return full structure, pass `Infinity` or some arbitrary large number. _Default_: `512`.
   - `buffer`: `<boolean>` Substitues instances of a `Buffer` object with their string representation: `"Buffer(N)"`. _Default_: `true`.
   - `getters`: `<boolean>` Omits getter fields in objects and classes from the result. _Default_: `true`.
-  - `ignore`: `<Record<string, unknown>>` A record of paths to ignore while at depth 0. For example trimming `{a: FooClass}` with `{ignore: { a: true }}` will result in `{a: FooClass}`. _Default_: `{}`
+  - `ignore`: `<Record<string, unknown>>` A record of paths to ignore while at depth 0. For example trimming `{a: FooClass}` with `{ignore: { a: true }}` will result in `{a: FooClass} instead of {a: {}}`. _Default_: `{}`
 
 - Returns: `<Function>` - trimmer function that accepts input argument of any type.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -151,3 +151,31 @@ test('rule: #getters', (t) => {
     },
   });
 });
+
+test('rule: #ignore', (t) => {
+  class Foo {
+    get foo() {
+      return 'foo';
+    }
+    set bar(_arg: any) {}
+    public baz() {
+      return 'baz';
+    }
+  }
+  const foo = new Foo();
+  const input = {
+    a: foo,
+    b: foo,
+    c: foo,
+  };
+
+  const output = trimmerFactory({
+    ignore: { a: () => {}, c: () => {} },
+  })(input);
+
+  t.deepEqual(output, {
+    a: foo,
+    b: {},
+    c: foo,
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export interface TrimmerOptions {
   string: number;
   buffer: boolean;
   getters: boolean;
+  ignore: Record<string, unknown>;
 }
 
 export type TrimmerOptionsInput = Partial<TrimmerOptions>;
@@ -16,6 +17,7 @@ const defaultOpts: TrimmerOptions = {
   string: 512,
   buffer: true,
   getters: true,
+  ignore: {},
 };
 
 const walker = (opts: TrimmerOptions, node: any, depth: number): any => {
@@ -64,6 +66,10 @@ const walker = (opts: TrimmerOptions, node: any, depth: number): any => {
   }
 
   for (const key in node) {
+    if (depth === 0 && opts.ignore[key]) {
+      output[key] = node[key];
+      continue;
+    }
     output[key] = walker(opts, node[key], depth + 1);
   }
 


### PR DESCRIPTION
`pino` doesn't actually call getters and rely on serializers to call them. So the `getters` option might not be the best way to do it.

I'm thinking about passing the `serializers` object to this trimmer library which is essentially just a record of paths to ignore.