### PR TITLE
fix: Stop calling getters on objects by default

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -123,22 +123,29 @@ test('rule: #getters', (t) => {
       return 'baz';
     }
   }
+  const object = {
+    get getter() {
+      return 'getter';
+    },
+  };
   const foo = new Foo();
   const symbol = Symbol('some desc');
   const map = new Map();
   const set = new Set('a');
   const input = {
     foo,
+    object,
     symbol,
     map,
     set,
   };
 
-  const output = trimmerFactory({ getters: false })(input);
-
-  t.deepEqual(output, {
+  t.deepEqual(trimmerFactory({ getters: false })(input), {
     foo: {
       foo: 'foo',
+    },
+    object: {
+      getter: 'getter',
     },
     symbol: {
       description: 'some desc',
@@ -149,6 +156,16 @@ test('rule: #getters', (t) => {
     set: {
       size: 1,
     },
+  });
+
+  t.deepEqual(trimmerFactory({ getters: true })(input), {
+    foo: {},
+    object: {
+      getter: '[Getter]',
+    },
+    symbol: {},
+    map: {},
+    set: {},
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,16 +65,27 @@ const walker = (opts: TrimmerOptions, node: any, depth: number): any => {
     output.name = node.name;
   }
 
+  const prototype = Object.getPrototypeOf(node);
+
   for (const key in node) {
     if (depth === 0 && opts.retain.has(key)) {
       output[key] = node[key];
       continue;
     }
+
+    if (
+      opts.getters === true &&
+      prototype &&
+      Object.getOwnPropertyDescriptor(node, key)?.get
+    ) {
+      output[key] = '[Getter]';
+      continue;
+    }
+
     output[key] = walker(opts, node[key], depth + 1);
   }
 
   if (opts.getters === false) {
-    const prototype = Object.getPrototypeOf(node);
     if (prototype) {
       const methods = Object.getOwnPropertyDescriptors(prototype);
       for (const key in methods) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,8 +65,6 @@ const walker = (opts: TrimmerOptions, node: any, depth: number): any => {
     output.name = node.name;
   }
 
-  const prototype = Object.getPrototypeOf(node);
-
   for (const key in node) {
     if (depth === 0 && opts.retain.has(key)) {
       output[key] = node[key];
@@ -75,7 +73,6 @@ const walker = (opts: TrimmerOptions, node: any, depth: number): any => {
 
     if (
       opts.getters === true &&
-      prototype &&
       Object.getOwnPropertyDescriptor(node, key)?.get
     ) {
       output[key] = '[Getter]';
@@ -86,6 +83,7 @@ const walker = (opts: TrimmerOptions, node: any, depth: number): any => {
   }
 
   if (opts.getters === false) {
+    const prototype = Object.getPrototypeOf(node);
     if (prototype) {
       const methods = Object.getOwnPropertyDescriptors(prototype);
       for (const key in methods) {


### PR DESCRIPTION
Resolves https://github.com/runk/dtrim/issues/507

This is actually how `console.log` works.